### PR TITLE
Check for records before matching a string.

### DIFF
--- a/scripts/omigod.zeek
+++ b/scripts/omigod.zeek
@@ -82,7 +82,7 @@ event http_all_headers(c: connection, is_orig: bool, hlist: mime_header_list)
         return;
 
     # The exploit is triggered when a payload XML is POSTed
-    if (c$http$method != "POST")
+    if ( !c?http || !c$http?method || c$http$method != "POST")
         return;
 
     # Throw out small list of headers


### PR DESCRIPTION
A fix for the following error in reporter.log:

```
Message:  field value missing CVE_2021_38647::c$http$method
Location:  [REDACTED]/CVE-2021-38647/./omigod.zeek, line 85"
```